### PR TITLE
default intent filter added to HomeActivity in manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
         <action android:name="android.intent.action.MAIN"/>
 
         <category android:name="android.intent.category.LAUNCHER"/>
+        <category android:name="android.intent.category.DEFAULT"/>
       </intent-filter>
     </activity>
 


### PR DESCRIPTION
App was crashing when clicking "Restart Application" in the drawer. One line added to manifest seems to have fixed it.